### PR TITLE
AWS CD를 위한 Github Actions 추가

### DIFF
--- a/.github/workflows/deploy_aws.yml
+++ b/.github/workflows/deploy_aws.yml
@@ -1,0 +1,28 @@
+name: AWS CD
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 14
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-acccess-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+    - name: npm install
+      run: npm ci
+    - name: deploy to lambda
+      run: |
+        zip -qq -j -r deploy.zip .
+        aws lambda update-function-code --function-name=waffle-account-authorizer --zip-file=fileb://deploy.zip
+


### PR DESCRIPTION
# 변경사항
AWS lambda의 CD를 지원하는 Github Actions workflow를 추가했습니다.
```npm ci```를 실행한 뒤 디렉토리를 압축하여 AWS에 업로드합니다.